### PR TITLE
updating doc, turns out I didn't need to add new attributes because we'v...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,4 +1,5 @@
-# The AD host IP address (or addresses) (IE: [ '192.168.1.100', '192.168.1.101' ])
+# The /etc/resolv.conf nameserver IP address (or addresses) (IE: [ '192.168.1.100', '192.168.1.101' ])
+# These must be able to resolve your AD domain, and *can* be set to Simple AD server IPs.
 default['resolver']['nameservers'] = nil
 
 # The AD domain (ie: example.com)


### PR DESCRIPTION
...e recently switched to using DNS name vs. IPs for Simple AD servers in /etc/sssd.conf