### PR TITLE
* adding support for pam_mkhomedir, with tests

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'oss@localytics.com'
 license          'Apache 2.0'
 description      'Installs/Configures sssd for use with an AD backend such as Amazon DS'
 long_description 'Installs/Configures sssd for use with an AD backend such as Amazon DS'
-version          '0.1.2'
+version          '0.2.0'
 
 depends 'apt', '~> 2.7.0'
 depends 'resolver', '~> 1.2.0'

--- a/templates/default/my_mkhomedir.erb
+++ b/templates/default/my_mkhomedir.erb
@@ -1,0 +1,6 @@
+Name: activate mkhomedir
+Default: yes
+Priority: 900
+Session-Type: Additional
+Session:
+        required                        pam_mkhomedir.so umask=0022 skel=/etc/skel

--- a/test/integration/default/serverspec/localhost/sssd_spec.rb
+++ b/test/integration/default/serverspec/localhost/sssd_spec.rb
@@ -26,3 +26,12 @@ end
 describe command("/usr/bin/sudo -U #{$node['sssd']['test_user']} -l") do
   its(:stdout) { should_not match /is not allowed to run sudo on/ }
 end
+
+# Used just to create the directory if it doesn't already exist
+describe command("/bin/su #{$node['sssd']['test_user']} -c /bin/true") do
+  its(:exit_status) { should eq 0 }
+end
+
+describe file("/home/#{$node['sssd']['test_user']}") do
+  it { should be_directory }
+end


### PR DESCRIPTION
* cleaning up default recipe code
* breaking change: now auto-creates home directories, runs pam-auth-update with --package which excludes user interaction