### PR TITLE
remove the expect dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1
+
+Remove the expect dependency and rely on `adcli`'s `--stdin-password` option instead
+
 # 0.1.0
 
 Initial release of sssd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-# 0.1.1
-
-Remove the expect dependency and rely on `adcli`'s `--stdin-password` option instead
-
-# 0.1.0
-
-Initial release of sssd

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,8 +1,8 @@
 case node['platform']
 when 'ubuntu'
-  default['sssd']['packages'] = %w(expect sssd sssd-ad sssd-ad-common sssd-tools adcli krb5-user)
+  default['sssd']['packages'] = %w(sssd sssd-ad sssd-ad-common sssd-tools adcli krb5-user)
 when 'centos'
-  default['sssd']['packages'] = %w(expect sssd sssd-ad sssd-common sssd-tools authconfig krb5-workstation)
+  default['sssd']['packages'] = %w(sssd sssd-ad sssd-common sssd-tools authconfig krb5-workstation)
 end
 
 default['sssd']['join_domain'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,5 @@ version          IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0
 supports 'ubuntu', '>= 14.04'
 supports 'centos', '>= 6.6'
 
+depends 'apt', '< 4'
 depends 'yum-epel', '~> 0.6.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,9 +50,9 @@ if node['sssd']['join_domain'] == true
   # The ideal here (and future PR) is "realm join", but for now, we use adcli due to:
   #   CentOS 6: realm is only available in RHEL/CentOS 7
   #   Ubuntu 14.04: due to necessary hacky work-arounds to this bug: https://bugs.launchpad.net/ubuntu/+source/realmd/+bug/1333694
-  bash 'join_domain' do
-    user 'root'
-    code "echo -n '#{realm_databag_contents['password']}' | adcli join --host-fqdn #{computer_name} -U #{realm_databag_contents['username']} #{node['sssd']['directory_name']} --stdin-password"
+  execute 'join_domain' do
+    sensitive true
+    command "echo -n '#{realm_databag_contents['password']}' | adcli join --host-fqdn #{computer_name} -U #{realm_databag_contents['username']} #{node['sssd']['directory_name']} --stdin-password"
     not_if "klist -k | grep -i '@#{node['sssd']['directory_name']}'"
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,12 +52,7 @@ if node['sssd']['join_domain'] == true
   #   Ubuntu 14.04: due to necessary hacky work-arounds to this bug: https://bugs.launchpad.net/ubuntu/+source/realmd/+bug/1333694
   bash 'join_domain' do
     user 'root'
-    code <<-EOF
-    /usr/bin/expect -c 'spawn adcli join --host-fqdn #{computer_name} -U #{realm_databag_contents['username']} #{node['sssd']['directory_name']}
-    expect "Password for #{realm_databag_contents['username']}: "
-    send "#{realm_databag_contents['password']}\r"
-    expect eof'
-    EOF
+    code "echo -n '#{realm_databag_contents['password']}' | adcli join --host-fqdn #{computer_name} -U #{realm_databag_contents['username']} #{node['sssd']['directory_name']} --stdin-password"
     not_if "klist -k | grep -i '@#{node['sssd']['directory_name']}'"
   end
 end


### PR DESCRIPTION
... and rely on `adcli`'s `--stdin-password` option instead