### PR TITLE
Make sssd service actions configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.1
+
+Make `sssd` service actions configurable with a new attribute `node['sssd']['service_actions']`. Defaults to
+`[:enable]`.
+
 # 0.5.0
 
 Use adcli --stdin-password to set the password instead of expect

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Launch, configure, and manage the SSSD service for communication with an AD back
     <td>databag item that contains the username and password used in "adcli join" or "realm join"</td>
     <td><tt>nil</tt></td>
   </tr>
+  <tr>
+    <td><tt>['sssd']['service_actions']</tt></td>
+    <td>Symbol | Array of symbols</td>
+    <td>the actions to run on the <tt>sssd</tt> service</td>
+    <td><tt>[:enable]</tt></td>
+  </tr>
 </table>
 
 ## Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,5 @@ default['sssd']['realm']['databag_item'] = 'realm'
 
 default['sssd']['adcli']['rpm'] = 'adcli-0.8.0-1.el6.x86_64.rpm'
 default['sssd']['adcli']['rpm_source'] = "https://s3.amazonaws.com/public.localytics/artifacts/#{node['sssd']['adcli']['rpm']}"
+
+default['sssd']['service_actions'] = [:enable]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,7 +46,7 @@ if node['sssd']['join_domain'] == true
   rescue
     Chef::Application.fatal!('Unable to access the encrypted data bag for domain credentials, ensure encrypted_data_bag_secret is available!')
   end
-  
+
   # The ideal here (and future PR) is "realm join", but for now, we use adcli due to:
   #   CentOS 6: realm is only available in RHEL/CentOS 7
   #   Ubuntu 14.04: due to necessary hacky work-arounds to this bug: https://bugs.launchpad.net/ubuntu/+source/realmd/+bug/1333694
@@ -98,5 +98,5 @@ end
 
 service 'sssd' do
   supports :status => true, :restart => true, :reload => true
-  action [:enable]
+  action node['sssd']['service_actions']
 end


### PR DESCRIPTION
Defaults to `[:enable]` to keep functionality the same