### PR TITLE
Revert the change to restart sssd on join_domain

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -54,7 +54,6 @@ if node['sssd']['join_domain'] == true
     sensitive true
     command "echo -n '#{realm_databag_contents['password']}' | adcli join --host-fqdn #{computer_name} -U #{realm_databag_contents['username']} #{node['sssd']['directory_name']} --stdin-password"
     not_if "klist -k | grep -i '@#{node['sssd']['directory_name']}'"
-    notifies :restart, 'service[sssd]', :immediately
   end
 end
 


### PR DESCRIPTION
This fails on centos since the sssd config is not in place yet during an
initial chef run.